### PR TITLE
Amend install.sh to load ghci to path immediately

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 echo "ANSWER YES TO EVERYTHING THAT IT ASKS YOU! Press enter in a minute."
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-. /home/codespace/.ghcup/env
 echo "Installer finished. See instructions in README.md"
 echo ":)"
+bash


### PR DESCRIPTION
This calls bash at the end of the install script which reloads the bash session, and so will reload .bashrc where the PATH changes that add GHCI and etc are set. This means that when the install is finished, running `$ ghci` will just work.